### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ SBB.py (Sina Blog URL) (asc|desc)
 
 The sort order argument is optional. By default, articles will be sorted chronically (asc).
 
-###Example:
+### Example:
 
 - SBB.py http://blog.sina.com.cn/gongmin desc
 - SBB.py http://blog.sina.com.cn/u/1239657051
@@ -25,14 +25,14 @@ The sort order argument is optional. By default, articles will be sorted chronic
 ## License
 Licensed under the Apache License, Version 2.0
 
-##Change log
+## Change log
 
-###Feb 15, 2015
+### Feb 15, 2015
 
 - [ADDED] timestamp for index and articles.
 - [ADDED] sort option. Ascending by default.
 
-#中文
+# 中文
 
 **SBB**(**S**ina **B**log **B**ook) 是一个用于下载指定新浪博客作者全部文章的脚本。
 
@@ -59,9 +59,9 @@ SBB.py (新浪博客地址) (desc|asc)
 ## 授权
 Licensed under the Apache License, Version 2.0
 
-##升级日志
+## 升级日志
 
-###2015年2月15日
+### 2015年2月15日
 
 - [增加] 索引页面和文章页面增加时间戳。
 - [增加] 文章排序选项，默认按发表时间顺序排列。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
